### PR TITLE
[TT-9916] Add current semantic convention attributes to spans for GQL

### DIFF
--- a/semconv/v1.0.0/graphql.go
+++ b/semconv/v1.0.0/graphql.go
@@ -1,0 +1,42 @@
+package semconv
+
+import (
+	"github.com/TykTechnologies/opentelemetry/trace"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+const (
+	// GraphQLOperationPrefix is the base prefix for all the GraphQL operation attributes
+	GraphQLOperationPrefix = "operation."
+)
+
+const (
+	// GraphQLOperationNameKey represents the name of the operation being executed.
+	GraphQLOperationNameKey = attribute.Key(GraphQLOperationPrefix + "name")
+
+	// GraphQLOperationTypeKey The type of the operation being executed.
+	GraphQLOperationTypeKey = attribute.Key(GraphQLOperationPrefix + "type")
+)
+
+const (
+	// GraphQLDocumentKey represents The GraphQL document being executed.
+	GraphQLDocumentKey = attribute.Key("document")
+)
+
+// GraphQLOperationName returns an attribute KeyValue conforming to the
+// "operation.name" semantic convention.
+func GraphQLOperationName(name string) trace.Attribute {
+	return GraphQLOperationNameKey.String(name)
+}
+
+// GraphQLOperationType returns an attribute KeyValue conforming to the
+// "operation.type" semantic convention.
+func GraphQLOperationType(operationType string) trace.Attribute {
+	return GraphQLOperationTypeKey.String(operationType)
+}
+
+// GraphQLDocument returns an attribute KeyValue conforming to the
+// "document" semantic convention.
+func GraphQLDocument(document string) trace.Attribute {
+	return GraphQLDocumentKey.String(document)
+}

--- a/semconv/v1.0.0/graphql_test.go
+++ b/semconv/v1.0.0/graphql_test.go
@@ -1,0 +1,29 @@
+package semconv
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func TestGraphQLOperationName(t *testing.T) {
+	name := "MyQuery"
+	expectedAttribute := attribute.Key(GraphQLOperationPrefix + "name").String(name)
+	actualAttribute := GraphQLOperationName(name)
+	assert.Equal(t, expectedAttribute, actualAttribute, "The attributes should be equal")
+}
+
+func TestGraphQLOperationType(t *testing.T) {
+	operationType := "mutation"
+	expectedAttribute := attribute.Key(GraphQLOperationPrefix + "type").String(operationType)
+	actualAttribute := GraphQLOperationType(operationType)
+	assert.Equal(t, expectedAttribute, actualAttribute, "The attributes should be equal")
+}
+
+func TestGraphQLDocument(t *testing.T) {
+	document := "query{}"
+	expectedAttribute := GraphQLDocumentKey.String(document)
+	actualAttribute := GraphQLDocument(document)
+	assert.Equal(t, expectedAttribute, actualAttribute, "The attributes should be equal")
+}


### PR DESCRIPTION
This PR adds the following attributes for GraphQL/UDG: 

- operation.name -> `func GraphQLOperationName(name string) trace.Attribute`
- operation.type -> `func GraphQLOperationType(operationType string) trace.Attribute`
- document -> `func GraphQLDocument(document string) trace.Attribute`

See [TT-9916](https://tyktech.atlassian.net/browse/TT-9916) for details.


[TT-9916]: https://tyktech.atlassian.net/browse/TT-9916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ