### PR TITLE
TT-16688 Add `metric/metrictest` package for unit-testable metrics

### DIFF
--- a/metric/metrictest/assert.go
+++ b/metric/metrictest/assert.go
@@ -1,0 +1,161 @@
+package metrictest
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// AssertSum asserts that a Sum (counter) metric has the expected total value
+// across all data points.
+//
+//	m := tp.FindMetric(t, "http.server.requests")
+//	metrictest.AssertSum(t, m, int64(10))
+func AssertSum[N int64 | float64](t testing.TB, m metricdata.Metrics, expected N) {
+	t.Helper()
+	switch data := m.Data.(type) {
+	case metricdata.Sum[int64]:
+		var total int64
+		for _, dp := range data.DataPoints {
+			total += dp.Value
+		}
+		if int64(expected) != total {
+			t.Errorf("metric %q: sum = %d, want %d", m.Name, total, int64(expected))
+		}
+	case metricdata.Sum[float64]:
+		var total float64
+		for _, dp := range data.DataPoints {
+			total += dp.Value
+		}
+		if float64(expected) != total {
+			t.Errorf("metric %q: sum = %f, want %f", m.Name, total, float64(expected))
+		}
+	default:
+		t.Fatalf("metric %q: expected Sum data, got %T", m.Name, m.Data)
+	}
+}
+
+// AssertSumWithAttrs asserts that a Sum metric has a data point with the
+// expected value AND the given attributes.
+//
+//	m := tp.FindMetric(t, "http.server.requests")
+//	metrictest.AssertSumWithAttrs(t, m, int64(5),
+//		attribute.String("http.request.method", "GET"),
+//		attribute.Int("http.response.status_code", 200),
+//	)
+func AssertSumWithAttrs[N int64 | float64](t testing.TB, m metricdata.Metrics, expected N, attrs ...attribute.KeyValue) {
+	t.Helper()
+	switch data := m.Data.(type) {
+	case metricdata.Sum[int64]:
+		for _, dp := range data.DataPoints {
+			if hasAttributes(dp.Attributes, attrs) && dp.Value == int64(expected) {
+				return
+			}
+		}
+		t.Errorf("metric %q: no data point with value %d and matching attributes", m.Name, int64(expected))
+	case metricdata.Sum[float64]:
+		for _, dp := range data.DataPoints {
+			if hasAttributes(dp.Attributes, attrs) && dp.Value == float64(expected) {
+				return
+			}
+		}
+		t.Errorf("metric %q: no data point with value %f and matching attributes", m.Name, float64(expected))
+	default:
+		t.Fatalf("metric %q: expected Sum data, got %T", m.Name, m.Data)
+	}
+}
+
+// AssertHistogramCount asserts the total observation count of a histogram.
+//
+//	m := tp.FindMetric(t, "http.server.request.duration")
+//	metrictest.AssertHistogramCount(t, m, uint64(100))
+func AssertHistogramCount(t testing.TB, m metricdata.Metrics, expected uint64) {
+	t.Helper()
+	data, ok := m.Data.(metricdata.Histogram[float64])
+	if !ok {
+		t.Fatalf("metric %q: expected Histogram data, got %T", m.Name, m.Data)
+	}
+	var total uint64
+	for _, dp := range data.DataPoints {
+		total += dp.Count
+	}
+	if expected != total {
+		t.Errorf("metric %q: histogram count = %d, want %d", m.Name, total, expected)
+	}
+}
+
+// AssertHistogramSum asserts the sum of all observed values of a histogram.
+//
+//	m := tp.FindMetric(t, "http.server.request.duration")
+//	metrictest.AssertHistogramSum(t, m, 1500.0)
+func AssertHistogramSum(t testing.TB, m metricdata.Metrics, expected float64) {
+	t.Helper()
+	data, ok := m.Data.(metricdata.Histogram[float64])
+	if !ok {
+		t.Fatalf("metric %q: expected Histogram data, got %T", m.Name, m.Data)
+	}
+	var total float64
+	for _, dp := range data.DataPoints {
+		total += dp.Sum
+	}
+	if expected != total {
+		t.Errorf("metric %q: histogram sum = %f, want %f", m.Name, total, expected)
+	}
+}
+
+// AssertGauge asserts that a gauge metric has the expected value.
+//
+//	m := tp.FindMetric(t, "system.memory.usage")
+//	metrictest.AssertGauge(t, m, 1024.0)
+func AssertGauge[N int64 | float64](t testing.TB, m metricdata.Metrics, expected N) {
+	t.Helper()
+	switch data := m.Data.(type) {
+	case metricdata.Gauge[int64]:
+		if len(data.DataPoints) == 0 {
+			t.Fatalf("metric %q: no data points", m.Name)
+		}
+		if data.DataPoints[0].Value != int64(expected) {
+			t.Errorf("metric %q: gauge = %d, want %d", m.Name, data.DataPoints[0].Value, int64(expected))
+		}
+	case metricdata.Gauge[float64]:
+		if len(data.DataPoints) == 0 {
+			t.Fatalf("metric %q: no data points", m.Name)
+		}
+		if data.DataPoints[0].Value != float64(expected) {
+			t.Errorf("metric %q: gauge = %f, want %f", m.Name, data.DataPoints[0].Value, float64(expected))
+		}
+	default:
+		t.Fatalf("metric %q: expected Gauge data, got %T", m.Name, m.Data)
+	}
+}
+
+// AssertHasAttributes asserts that at least one data point in the metric
+// contains all of the given attributes (subset match).
+//
+//	m := tp.FindMetric(t, "http.server.requests")
+//	metrictest.AssertHasAttributes(t, m,
+//		attribute.String("http.request.method", "POST"),
+//	)
+func AssertHasAttributes(t testing.TB, m metricdata.Metrics, attrs ...attribute.KeyValue) {
+	t.Helper()
+	for _, set := range dataPointAttributeSets(m) {
+		if hasAttributes(set, attrs) {
+			return
+		}
+	}
+	t.Errorf("metric %q: no data point contains all given attributes", m.Name)
+}
+
+// AssertDataPointCount asserts the number of distinct data points (unique
+// attribute combinations) recorded for a metric.
+//
+//	m := tp.FindMetric(t, "http.server.requests")
+//	metrictest.AssertDataPointCount(t, m, 3) // 3 unique method+status combos
+func AssertDataPointCount(t testing.TB, m metricdata.Metrics, expected int) {
+	t.Helper()
+	count := dataPointCount(m)
+	if expected != count {
+		t.Errorf("metric %q: data points = %d, want %d", m.Name, count, expected)
+	}
+}

--- a/metric/metrictest/doc.go
+++ b/metric/metrictest/doc.go
@@ -1,0 +1,129 @@
+// Package metrictest provides test utilities for the metric package.
+//
+// It allows unit tests to create a real (non-noop) metric provider that
+// records actual values, without requiring any network, config, or OTLP
+// collector. Tests can then collect recorded data and assert on metric
+// values, attributes, and counts.
+//
+// # Quick Start
+//
+// Create a test provider, record metrics, and assert:
+//
+//	func TestRequestCounter(t *testing.T) {
+//		tp := metrictest.NewProvider(t)
+//
+//		counter, err := tp.NewCounter("http.requests", "Total requests", "1")
+//		require.NoError(t, err)
+//
+//		ctx := context.Background()
+//		counter.Add(ctx, 1, attribute.String("method", "GET"))
+//		counter.Add(ctx, 3, attribute.String("method", "POST"))
+//
+//		// Assert counter values.
+//		m := tp.FindMetric(t, "http.requests")
+//		metrictest.AssertSum(t, m, int64(4))
+//		metrictest.AssertDataPointCount(t, m, 2) // GET and POST
+//	}
+//
+// # Testing Histograms
+//
+// Histogram assertions support count, sum, and attributes:
+//
+//	func TestLatencyHistogram(t *testing.T) {
+//		tp := metrictest.NewProvider(t)
+//
+//		hist, err := tp.NewHistogram(
+//			"http.duration", "Request duration", "ms", nil,
+//		)
+//		require.NoError(t, err)
+//
+//		ctx := context.Background()
+//		hist.Record(ctx, 50.0, attribute.String("route", "/api/v1"))
+//		hist.Record(ctx, 150.0, attribute.String("route", "/api/v1"))
+//
+//		m := tp.FindMetric(t, "http.duration")
+//		metrictest.AssertHistogramCount(t, m, uint64(2))
+//		metrictest.AssertHistogramSum(t, m, 200.0)
+//	}
+//
+// # Testing Gauges
+//
+// Gauges record the latest value:
+//
+//	func TestPoolSize(t *testing.T) {
+//		tp := metrictest.NewProvider(t)
+//
+//		gauge, err := tp.NewGauge("pool.size", "Connection pool size", "1")
+//		require.NoError(t, err)
+//
+//		ctx := context.Background()
+//		gauge.Record(ctx, 42.0)
+//
+//		m := tp.FindMetric(t, "pool.size")
+//		metrictest.AssertGauge(t, m, 42.0)
+//	}
+//
+// # Attribute Assertions
+//
+// Verify that metrics are recorded with the correct attributes:
+//
+//	func TestCounterAttributes(t *testing.T) {
+//		tp := metrictest.NewProvider(t)
+//
+//		counter, _ := tp.NewCounter("api.calls", "API calls", "1")
+//
+//		ctx := context.Background()
+//		counter.Add(ctx, 1,
+//			attribute.String("api.id", "api-123"),
+//			attribute.String("http.request.method", "GET"),
+//			attribute.Int("http.response.status_code", 200),
+//		)
+//
+//		m := tp.FindMetric(t, "api.calls")
+//		metrictest.AssertSumWithAttrs(t, m, int64(1),
+//			attribute.String("api.id", "api-123"),
+//			attribute.String("http.request.method", "GET"),
+//		)
+//	}
+//
+// # Advanced: Raw metricdata Access
+//
+// For complex assertions, use Collect() to get the raw OTel metricdata
+// types and combine with metricdatatest.AssertEqual:
+//
+//	func TestAdvanced(t *testing.T) {
+//		tp := metrictest.NewProvider(t)
+//		// ... record metrics ...
+//
+//		rm := tp.Collect()
+//		for _, sm := range rm.ScopeMetrics {
+//			for _, m := range sm.Metrics {
+//				// Full access to metricdata types.
+//			}
+//		}
+//	}
+//
+// # Debugging
+//
+// Use MetricNames() to see what was recorded:
+//
+//	names := tp.MetricNames()
+//	t.Logf("recorded metrics: %v", names)
+//
+// # Parallel Tests
+//
+// Each TestProvider is fully isolated — no global state is set.
+// Safe for use with t.Parallel():
+//
+//	func TestA(t *testing.T) {
+//		t.Parallel()
+//		tp := metrictest.NewProvider(t)
+//		// ...
+//	}
+//
+//	func TestB(t *testing.T) {
+//		t.Parallel()
+//		tp := metrictest.NewProvider(t)
+//		// ...
+//	}
+package metrictest

--- a/metric/metrictest/helpers.go
+++ b/metric/metrictest/helpers.go
@@ -1,0 +1,71 @@
+package metrictest
+
+import (
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// hasAttributes checks if attrSet contains all of the wanted attributes.
+func hasAttributes(attrSet attribute.Set, wanted []attribute.KeyValue) bool {
+	for _, w := range wanted {
+		val, found := attrSet.Value(w.Key)
+		if !found || val != w.Value {
+			return false
+		}
+	}
+	return true
+}
+
+// dataPointAttributeSets extracts attribute sets from all data points.
+func dataPointAttributeSets(m metricdata.Metrics) []attribute.Set {
+	switch data := m.Data.(type) {
+	case metricdata.Sum[int64]:
+		sets := make([]attribute.Set, len(data.DataPoints))
+		for i, dp := range data.DataPoints {
+			sets[i] = dp.Attributes
+		}
+		return sets
+	case metricdata.Sum[float64]:
+		sets := make([]attribute.Set, len(data.DataPoints))
+		for i, dp := range data.DataPoints {
+			sets[i] = dp.Attributes
+		}
+		return sets
+	case metricdata.Histogram[float64]:
+		sets := make([]attribute.Set, len(data.DataPoints))
+		for i, dp := range data.DataPoints {
+			sets[i] = dp.Attributes
+		}
+		return sets
+	case metricdata.Gauge[float64]:
+		sets := make([]attribute.Set, len(data.DataPoints))
+		for i, dp := range data.DataPoints {
+			sets[i] = dp.Attributes
+		}
+		return sets
+	case metricdata.Gauge[int64]:
+		sets := make([]attribute.Set, len(data.DataPoints))
+		for i, dp := range data.DataPoints {
+			sets[i] = dp.Attributes
+		}
+		return sets
+	}
+	return nil
+}
+
+// dataPointCount returns the number of data points in a metric.
+func dataPointCount(m metricdata.Metrics) int {
+	switch data := m.Data.(type) {
+	case metricdata.Sum[int64]:
+		return len(data.DataPoints)
+	case metricdata.Sum[float64]:
+		return len(data.DataPoints)
+	case metricdata.Histogram[float64]:
+		return len(data.DataPoints)
+	case metricdata.Gauge[float64]:
+		return len(data.DataPoints)
+	case metricdata.Gauge[int64]:
+		return len(data.DataPoints)
+	}
+	return 0
+}

--- a/metric/metrictest/provider.go
+++ b/metric/metrictest/provider.go
@@ -1,0 +1,97 @@
+package metrictest
+
+import (
+	"context"
+	"testing"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/TykTechnologies/opentelemetry/metric"
+)
+
+// TestProvider is a metric.Provider backed by a ManualReader for use in tests.
+// It records real metric data that can be collected and asserted on.
+//
+// TestProvider registers a t.Cleanup handler that calls Shutdown automatically.
+type TestProvider struct {
+	metric.Provider
+	reader *sdkmetric.ManualReader
+}
+
+// NewProvider creates a test provider with a ManualReader. No config, no
+// exporter, no network, no global state. Safe for parallel tests.
+//
+//	tp := metrictest.NewProvider(t)
+//	counter, _ := tp.NewCounter("hits", "Total hits", "1")
+//	counter.Add(ctx, 5)
+func NewProvider(t testing.TB) *TestProvider {
+	t.Helper()
+
+	reader := sdkmetric.NewManualReader()
+	provider, err := metric.NewProvider(
+		metric.WithContext(context.Background()),
+		metric.WithReader(reader),
+	)
+	if err != nil {
+		t.Fatalf("metrictest.NewProvider: %v", err)
+	}
+
+	tp := &TestProvider{
+		Provider: provider,
+		reader:   reader,
+	}
+	t.Cleanup(func() {
+		//nolint:errcheck // best-effort cleanup in tests
+		tp.Shutdown(context.Background())
+	})
+	return tp
+}
+
+// Collect gathers all recorded metrics and returns the raw ResourceMetrics.
+// Use this when you need full access to the OTel metricdata types, or when
+// combining with metricdatatest.AssertEqual for exact matching.
+//
+//	rm := tp.Collect()
+//	// inspect rm.ScopeMetrics directly
+func (tp *TestProvider) Collect() metricdata.ResourceMetrics {
+	var rm metricdata.ResourceMetrics
+	// ManualReader.Collect does not fail under normal test conditions.
+	//nolint:errcheck // intentional — ManualReader.Collect is infallible in tests
+	tp.reader.Collect(context.Background(), &rm)
+	return rm
+}
+
+// FindMetric collects metrics and returns the one matching name.
+// Fails the test if not found.
+//
+//	m := tp.FindMetric(t, "http.server.request.duration")
+func (tp *TestProvider) FindMetric(t testing.TB, name string) metricdata.Metrics {
+	t.Helper()
+	rm := tp.Collect()
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == name {
+				return m
+			}
+		}
+	}
+	t.Fatalf("metric %q not found; recorded: %v", name, tp.MetricNames())
+	return metricdata.Metrics{} // unreachable
+}
+
+// MetricNames collects metrics and returns all recorded metric names.
+// Useful for debugging when FindMetric fails or for snapshot tests.
+//
+//	names := tp.MetricNames()
+//	// ["http.server.request.duration", "http.server.active_requests", ...]
+func (tp *TestProvider) MetricNames() []string {
+	rm := tp.Collect()
+	var names []string
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			names = append(names, m.Name)
+		}
+	}
+	return names
+}

--- a/metric/metrictest/provider_test.go
+++ b/metric/metrictest/provider_test.go
@@ -1,0 +1,201 @@
+package metrictest_test
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/TykTechnologies/opentelemetry/metric/metrictest"
+)
+
+func TestNewProvider(t *testing.T) {
+	tp := metrictest.NewProvider(t)
+	if !tp.Enabled() {
+		t.Fatal("expected provider to be enabled")
+	}
+	if tp.Type() != "otel" {
+		t.Fatalf("expected type otel, got %s", tp.Type())
+	}
+}
+
+func TestCounter_AssertSum(t *testing.T) {
+	tp := metrictest.NewProvider(t)
+	counter, err := tp.NewCounter("test.counter", "A test counter", "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	counter.Add(ctx, 3)
+	counter.Add(ctx, 7)
+
+	m := tp.FindMetric(t, "test.counter")
+	metrictest.AssertSum(t, m, int64(10))
+}
+
+func TestCounter_AssertSumWithAttrs(t *testing.T) {
+	tp := metrictest.NewProvider(t)
+	counter, err := tp.NewCounter("test.counter.attrs", "A test counter", "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	counter.Add(ctx, 5, attribute.String("method", "GET"))
+	counter.Add(ctx, 3, attribute.String("method", "POST"))
+
+	m := tp.FindMetric(t, "test.counter.attrs")
+	metrictest.AssertSum(t, m, int64(8))
+	metrictest.AssertSumWithAttrs(t, m, int64(5), attribute.String("method", "GET"))
+	metrictest.AssertSumWithAttrs(t, m, int64(3), attribute.String("method", "POST"))
+}
+
+func TestHistogram_AssertCountAndSum(t *testing.T) {
+	tp := metrictest.NewProvider(t)
+	hist, err := tp.NewHistogram("test.histogram", "A test histogram", "ms", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	hist.Record(ctx, 50.0)
+	hist.Record(ctx, 150.0)
+	hist.Record(ctx, 100.0)
+
+	m := tp.FindMetric(t, "test.histogram")
+	metrictest.AssertHistogramCount(t, m, uint64(3))
+	metrictest.AssertHistogramSum(t, m, 300.0)
+}
+
+func TestGauge_AssertGauge(t *testing.T) {
+	tp := metrictest.NewProvider(t)
+	gauge, err := tp.NewGauge("test.gauge", "A test gauge", "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	gauge.Record(ctx, 42.0)
+
+	m := tp.FindMetric(t, "test.gauge")
+	metrictest.AssertGauge(t, m, 42.0)
+}
+
+func TestUpDownCounter_AssertSum(t *testing.T) {
+	tp := metrictest.NewProvider(t)
+	counter, err := tp.NewUpDownCounter("test.updown", "A test updown counter", "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	counter.Add(ctx, 5)
+	counter.Add(ctx, -2)
+
+	m := tp.FindMetric(t, "test.updown")
+	metrictest.AssertSum(t, m, int64(3))
+}
+
+func TestAssertHasAttributes(t *testing.T) {
+	tp := metrictest.NewProvider(t)
+	counter, err := tp.NewCounter("test.attrs", "A test counter", "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	counter.Add(ctx, 1,
+		attribute.String("key1", "val1"),
+		attribute.String("key2", "val2"),
+		attribute.Int("key3", 42),
+	)
+
+	m := tp.FindMetric(t, "test.attrs")
+	// Subset match — only checking key1 and key3.
+	metrictest.AssertHasAttributes(t, m,
+		attribute.String("key1", "val1"),
+		attribute.Int("key3", 42),
+	)
+}
+
+func TestAssertDataPointCount(t *testing.T) {
+	tp := metrictest.NewProvider(t)
+	counter, err := tp.NewCounter("test.dp.count", "A test counter", "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	counter.Add(ctx, 1, attribute.String("method", "GET"))
+	counter.Add(ctx, 2, attribute.String("method", "POST"))
+	counter.Add(ctx, 3, attribute.String("method", "DELETE"))
+
+	m := tp.FindMetric(t, "test.dp.count")
+	metrictest.AssertDataPointCount(t, m, 3)
+}
+
+func TestMetricNames(t *testing.T) {
+	tp := metrictest.NewProvider(t)
+
+	ctx := context.Background()
+
+	c1, err := tp.NewCounter("counter.a", "Counter A", "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	c1.Add(ctx, 1)
+	c2, err := tp.NewCounter("counter.b", "Counter B", "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	c2.Add(ctx, 1)
+	h1, err := tp.NewHistogram("hist.a", "Hist A", "ms", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h1.Record(ctx, 1.0)
+
+	names := tp.MetricNames()
+	if len(names) < 3 {
+		t.Fatalf("expected at least 3 metric names, got %d: %v", len(names), names)
+	}
+
+	nameSet := make(map[string]bool)
+	for _, n := range names {
+		nameSet[n] = true
+	}
+	for _, expected := range []string{"counter.a", "counter.b", "hist.a"} {
+		if !nameSet[expected] {
+			t.Errorf("expected metric %q in names %v", expected, names)
+		}
+	}
+}
+
+func TestParallelProviders(t *testing.T) {
+	t.Run("provider_a", func(t *testing.T) {
+		t.Parallel()
+		tp := metrictest.NewProvider(t)
+		counter, err := tp.NewCounter("parallel.a", "Counter A", "1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		counter.Add(context.Background(), 10)
+
+		m := tp.FindMetric(t, "parallel.a")
+		metrictest.AssertSum(t, m, int64(10))
+	})
+
+	t.Run("provider_b", func(t *testing.T) {
+		t.Parallel()
+		tp := metrictest.NewProvider(t)
+		counter, err := tp.NewCounter("parallel.b", "Counter B", "1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		counter.Add(context.Background(), 20)
+
+		m := tp.FindMetric(t, "parallel.b")
+		metrictest.AssertSum(t, m, int64(20))
+	})
+}

--- a/metric/options.go
+++ b/metric/options.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 
 	"github.com/TykTechnologies/opentelemetry/config"
 )
@@ -178,6 +179,19 @@ func WithCustomResourceAttributes(attrs ...Attribute) Option {
 	return &opts{
 		fn: func(mp *meterProvider) {
 			mp.resources.customAttrs = attrs
+		},
+	}
+}
+
+// WithReader injects a custom sdkmetric.Reader into the meter provider.
+// When set, the provider skips exporter creation and uses this reader instead.
+// The custom reader implies metrics are enabled — no WithConfig needed.
+//
+// Most consumers should use metric/metrictest.NewProvider instead.
+func WithReader(reader sdkmetric.Reader) Option {
+	return &opts{
+		fn: func(mp *meterProvider) {
+			mp.customReader = reader
 		},
 	}
 }

--- a/metric/provider_test.go
+++ b/metric/provider_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/TykTechnologies/opentelemetry/config"
 )
@@ -213,6 +215,135 @@ func TestNewProvider_NoopShutdown(t *testing.T) {
 func TestNewProvider_NoopForceFlush(t *testing.T) {
 	cfg := &config.MetricsConfig{Enabled: ptr(false)}
 	provider, err := NewProvider(WithContext(context.Background()), WithConfig(cfg))
+	assert.NoError(t, err)
+	assert.NoError(t, provider.ForceFlush(context.Background()))
+}
+
+func TestNewProvider_WithReader(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider, err := NewProvider(
+		WithContext(context.Background()),
+		WithReader(reader),
+	)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, provider)
+	assert.Equal(t, OtelProvider, provider.Type())
+	assert.True(t, provider.Enabled())
+	assert.True(t, provider.Healthy())
+}
+
+func TestNewProvider_WithReader_Counter(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider, err := NewProvider(
+		WithContext(context.Background()),
+		WithReader(reader),
+	)
+	assert.NoError(t, err)
+
+	counter, err := provider.NewCounter("test.counter", "A test counter", "1")
+	assert.NoError(t, err)
+	assert.True(t, counter.Enabled())
+
+	ctx := context.Background()
+	counter.Add(ctx, 5)
+
+	var rm metricdata.ResourceMetrics
+	assert.NoError(t, reader.Collect(ctx, &rm))
+
+	// Find the counter metric.
+	var found bool
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == "test.counter" {
+				sum, ok := m.Data.(metricdata.Sum[int64])
+				assert.True(t, ok)
+				assert.Len(t, sum.DataPoints, 1)
+				assert.Equal(t, int64(5), sum.DataPoints[0].Value)
+				found = true
+			}
+		}
+	}
+	assert.True(t, found, "metric test.counter not found")
+}
+
+func TestNewProvider_WithReader_Histogram(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider, err := NewProvider(
+		WithContext(context.Background()),
+		WithReader(reader),
+	)
+	assert.NoError(t, err)
+
+	histogram, err := provider.NewHistogram("test.histogram", "A test histogram", "ms", nil)
+	assert.NoError(t, err)
+	assert.True(t, histogram.Enabled())
+
+	ctx := context.Background()
+	histogram.Record(ctx, 50.0)
+	histogram.Record(ctx, 150.0)
+
+	var rm metricdata.ResourceMetrics
+	assert.NoError(t, reader.Collect(ctx, &rm))
+
+	var found bool
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == "test.histogram" {
+				hist, ok := m.Data.(metricdata.Histogram[float64])
+				assert.True(t, ok)
+				assert.Len(t, hist.DataPoints, 1)
+				assert.Equal(t, uint64(2), hist.DataPoints[0].Count)
+				assert.Equal(t, 200.0, hist.DataPoints[0].Sum)
+				found = true
+			}
+		}
+	}
+	assert.True(t, found, "metric test.histogram not found")
+}
+
+func TestNewProvider_WithReader_NoGlobalState(t *testing.T) {
+	// WithReader should NOT set the global meter provider.
+	reader := sdkmetric.NewManualReader()
+	_, err := NewProvider(
+		WithContext(context.Background()),
+		WithReader(reader),
+	)
+	assert.NoError(t, err)
+
+	// The global provider should still be the default noop, not our custom one.
+	// We can't easily assert this without side effects, but we verify the provider
+	// was created without error and is enabled.
+}
+
+func TestNewProvider_WithReader_NoConfigNeeded(t *testing.T) {
+	// WithReader should work without WithConfig — no Enabled flag needed.
+	reader := sdkmetric.NewManualReader()
+	provider, err := NewProvider(
+		WithContext(context.Background()),
+		WithReader(reader),
+	)
+	assert.NoError(t, err)
+	assert.True(t, provider.Enabled())
+	assert.Equal(t, OtelProvider, provider.Type())
+}
+
+func TestNewProvider_WithReader_Shutdown(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider, err := NewProvider(
+		WithContext(context.Background()),
+		WithReader(reader),
+	)
+	assert.NoError(t, err)
+	assert.NoError(t, provider.Shutdown(context.Background()))
+}
+
+func TestNewProvider_WithReader_ForceFlush(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider, err := NewProvider(
+		WithContext(context.Background()),
+		WithReader(reader),
+	)
 	assert.NoError(t, err)
 	assert.NoError(t, provider.ForceFlush(context.Background()))
 }


### PR DESCRIPTION

## Description
- Add `WithReader` option to inject a custom `sdkmetric.Reader` into the meter provider, enabling test providers backed by `ManualReader`
- Add `metric/metrictest` package that wraps this into a one-liner test API - consumers get real metric assertions without importing any OTel SDK packages
- Zero breaking changes - existing API and behavior unchanged

## Motivation

Consumers like `tyk/internal/otel` can currently only test with noop providers, asserting "no panic" but never verifying actual metric values, attributes, or counts. The OTel SDK's `ManualReader` solves this, but using it directly leaks SDK internals (`metricdata`, `ResourceMetrics` walks, type assertions) into every test file.

## What changed

**`metric/options.go`** - new `WithReader(reader sdkmetric.Reader) Option`

**`metric/provider.go`** - `customReader` field + early-return branch that bypasses exporter creation, periodic reader, stats tracking, and global provider registration

**`metric/metrictest/`** - new package (follows `net/http/httptest` convention):
- `NewProvider(t)` -  one-liner setup, auto-cleanup via `t.Cleanup`
- `FindMetric(t, name)` / `Collect()` / `MetricNames()` - collection helpers
- `AssertSum`, `AssertSumWithAttrs`, `AssertHistogramCount`, `AssertHistogramSum`, `AssertGauge`, `AssertHasAttributes`, `AssertDataPointCount` - assertion helpers with generics

**Before:**
```go
provider, _ := metric.NewProvider(metric.WithContext(ctx)) // noop
// Can only assert "no panic"
```

**After:**
```go
tp := metrictest.NewProvider(t)
counter, _ := tp.NewCounter("requests", "Total", "1")
counter.Add(ctx, 5, attribute.String("method", "GET"))

m := tp.FindMetric(t, "requests")
metrictest.AssertSum(t, m, int64(5))
metrictest.AssertHasAttributes(t, m, attribute.String("method", "GET"))
```
## Test Coverage For This Change
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of
the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)
- [ ] Documentation updates or improvements.


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] I have [reviewed the guidelines](./CONTRIBUTING.md) for contributing to this repository.
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [ ] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
     - [ ] I have manually updated the README(s)/documentation accordingly.
     - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
    - [ ] `gofmt -s -w .`
    - [ ] `go vet ./...`
