### PR TITLE
Fix sync/atomic.Value panic in statsExporter

### DIFF
--- a/metric/provider.go
+++ b/metric/provider.go
@@ -2,7 +2,6 @@ package metric
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -15,9 +14,14 @@ import (
 	"github.com/TykTechnologies/opentelemetry/config"
 )
 
-// errNoExportError is a sentinel stored in lastExportError after a successful
-// export, because atomic.Value.Store panics on nil.
-var errNoExportError = errors.New("")
+// exportErrorBox wraps an error so that atomic.Value always stores the same
+// concrete type (*exportErrorBox). Without this, storing different concrete
+// error types causes a panic: "sync/atomic: store of inconsistently typed
+// value into Value".
+type exportErrorBox struct{ err error }
+
+// noExportError is stored after a successful export to signal "no error".
+var noExportError = &exportErrorBox{}
 
 const (
 	// NoopProvider indicates a noop provider type.
@@ -248,7 +252,7 @@ func (e *statsExporter) Export(ctx context.Context, rm *metricdata.ResourceMetri
 	err := e.exporter.Export(ctx, rm)
 	if err != nil {
 		e.provider.failedExports.Add(1)
-		e.provider.lastExportError.Store(err)
+		e.provider.lastExportError.Store(&exportErrorBox{err: err})
 		e.provider.healthy.Store(false)
 		e.provider.logger.Error("metric export failed", err)
 		return err
@@ -257,10 +261,7 @@ func (e *statsExporter) Export(ctx context.Context, rm *metricdata.ResourceMetri
 	e.provider.successExports.Add(1)
 	e.provider.lastSuccessTime.Store(time.Now())
 	e.provider.healthy.Store(true)
-	// Note: we cannot store nil into atomic.Value (it panics), so we store a
-	// sentinel empty-message error to signal "no error". LastExportError()
-	// checks for this and returns nil.
-	e.provider.lastExportError.Store(errNoExportError)
+	e.provider.lastExportError.Store(noExportError)
 	return nil
 }
 
@@ -328,8 +329,8 @@ func (mp *meterProvider) LastExportError() error {
 		return nil
 	}
 	if v := mp.lastExportError.Load(); v != nil {
-		if err, ok := v.(error); ok && !errors.Is(err, errNoExportError) {
-			return err
+		if box, ok := v.(*exportErrorBox); ok && box.err != nil {
+			return box.err
 		}
 	}
 	return nil

--- a/metric/provider_test.go
+++ b/metric/provider_test.go
@@ -2,6 +2,7 @@ package metric
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -327,6 +328,55 @@ func TestNewProvider_WithReader_NoConfigNeeded(t *testing.T) {
 	assert.True(t, provider.Enabled())
 	assert.Equal(t, OtelProvider, provider.Type())
 }
+
+// TestStatsExporter_MixedErrorTypes verifies that the statsExporter does not
+// panic when storing errors of different concrete types (success sentinel vs
+// real export error) into the atomic.Value.
+func TestStatsExporter_MixedErrorTypes(t *testing.T) {
+	mp := &meterProvider{enabled: true, logger: &noopLogger{}}
+	failErr := fmt.Errorf("wrapped: %w", fmt.Errorf("inner"))
+	exporter := &statsExporter{
+		exporter: &fakeExporter{errs: []error{nil, failErr, nil}},
+		provider: mp,
+	}
+	ctx := context.Background()
+	rm := &metricdata.ResourceMetrics{}
+
+	// Cycle: success → failure → success. Before the fix the second or third
+	// call would panic due to inconsistent concrete types in atomic.Value.
+	assert.NoError(t, exporter.Export(ctx, rm))
+	assert.Nil(t, mp.LastExportError())
+
+	assert.Error(t, exporter.Export(ctx, rm))
+	assert.ErrorIs(t, mp.LastExportError(), failErr)
+
+	assert.NoError(t, exporter.Export(ctx, rm))
+	assert.Nil(t, mp.LastExportError())
+}
+
+// fakeExporter is a test double that returns errors from a pre-defined
+// sequence, cycling when the sequence is exhausted.
+type fakeExporter struct {
+	errs []error
+	idx  int
+}
+
+func (f *fakeExporter) Export(_ context.Context, _ *metricdata.ResourceMetrics) error {
+	err := f.errs[f.idx%len(f.errs)]
+	f.idx++
+	return err
+}
+
+func (f *fakeExporter) Temporality(sdkmetric.InstrumentKind) metricdata.Temporality {
+	return metricdata.CumulativeTemporality
+}
+
+func (f *fakeExporter) Aggregation(sdkmetric.InstrumentKind) sdkmetric.Aggregation {
+	return sdkmetric.DefaultAggregationSelector(0)
+}
+
+func (f *fakeExporter) Shutdown(context.Context) error   { return nil }
+func (f *fakeExporter) ForceFlush(context.Context) error { return nil }
 
 func TestNewProvider_WithReader_Shutdown(t *testing.T) {
 	reader := sdkmetric.NewManualReader()


### PR DESCRIPTION
## Summary

- Fix a runtime panic in `statsExporter.Export` caused by storing errors of different concrete types into a `sync/atomic.Value`
- The success path stored `*errors.errorString` (sentinel) while the failure path stored arbitrary error types (e.g., gRPC `*status.Error`), triggering `sync/atomic: store of inconsistently typed value into Value`
- Wrap all errors in a consistent `*exportErrorBox` struct before storing, ensuring type consistency

## Details

The `atomic.Value` contract requires all `Store` calls to use the same concrete type. Before this fix:

```
// success: stores *errors.errorString
lastExportError.Store(errors.New(""))

// failure: stores whatever error type the exporter returns
lastExportError.Store(err)  // e.g., *status.Error from gRPC
```

After this fix, all stores use `*exportErrorBox{err: ...}`.

## Test plan

- [x] Add `TestStatsExporter_MixedErrorTypes` — cycles success→failure→success with different error types to reproduce the exact panic
- [x] All existing metric tests pass with `-race`