### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -5,21 +5,36 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
+  dep-guard:
+    uses: TykTechnologies/github-actions/.github/workflows/dependency-guard.yml@d3fa20888fa2878e877e22bb7702141217290e7c # main
+    permissions:
+      contents: read
+
   ci-test:
     name: gotest
+    needs: [dep-guard]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 2
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
         with:
           version: 3
       - name: Setup Golang
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: 1.24.0
 

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,9 +1,15 @@
 name: "CLA Assistant"
+
 on:
   issue_comment:
     types: [created]
   pull_request_target:
     types: [opened,closed,synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
 
 jobs:
   CLAssistant:
@@ -11,26 +17,15 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        # Beta Release
-        uses: contributor-assistant/github-action@v2.2.0
+        uses: contributor-assistant/github-action@b2a7f9fb90217ea0b8a0c95c288221457be4a31f # v2.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN : ${{ secrets.ORG_GH_TOKEN}}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
         with:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://github.com/TykTechnologies/tyk/blob/master/CLA.md'
-          # branch should not be protected
           branch: 'main'
-          ##people who don't have to sign the CLA comma separated e.g user1,user2
           allowlist: bot*
-
-          #below are the optional inputs - If the optional inputs are not given, then default values will be taken
           remote-organization-name: 'TykTechnologies'
-          remote-repository-name:  'cla'
-          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
-          #signed-commit-message: 'For example: $contributorName has signed the CLA in #$pullRequestNo'
-          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
-          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
-          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
+          remote-repository-name: 'cla'
           lock-pullrequest-aftermerge: false
-

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,25 +1,40 @@
-name: CI tests
+name: E2E tests
 
 on:
   pull_request:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
+  dep-guard:
+    uses: TykTechnologies/github-actions/.github/workflows/dependency-guard.yml@d3fa20888fa2878e877e22bb7702141217290e7c # main
+    permissions:
+      contents: read
+
   e2e:
     name: e2e
+    needs: [dep-guard]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 2
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
         with:
           version: 3
       - name: Setup Golang
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: 1.24.0
       - name: Setup e2e
@@ -32,18 +47,21 @@ jobs:
 
   e2e-metrics:
     name: e2e-metrics
+    needs: [dep-guard]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 2
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
         with:
           version: 3
       - name: Setup Golang
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: 1.24.0
       - name: Run e2e metrics tests

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,28 +1,31 @@
 name: golangci-lint
+
 on:
-  push:
-    branches:
-      - master
-      - main
   pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
-  # Optional: allow read access to pull request. Use with `only-new-issues` option.
-  # pull-requests: read
 
 jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.24.0'
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
         with:
           version: v2.8.0
           only-new-issues: true


### PR DESCRIPTION
## Summary
Aligns this repo's GitHub Actions with the hardening patterns used in TykTechnologies/tyk master.

### Changes
- **SHA-pin all actions** — replaces mutable tags (`@v2`, `@v4`) with full commit SHAs to prevent supply chain attacks
- **Update outdated actions** — `actions/checkout` v2→v4, `actions/setup-go` v4→v5
- **Add permissions blocks** — explicit least-privilege `permissions:` on all workflows and jobs
- **Add concurrency controls** — prevents duplicate workflow runs on the same PR
- **Add dependency-guard** — blocks CI on dependency changes until reviewed (`deps-reviewed` label), using the shared `TykTechnologies/github-actions` reusable workflow
- **Add dependabot** — automatic PRs for GitHub Actions updates

### What was missing vs tyk master
| Feature | Before | After |
|---|---|---|
| SHA-pinned actions | None | All pinned |
| actions/checkout version | v2 (Node 12, deprecated) | v4 |
| Permissions blocks | Only on linter | All workflows |
| Concurrency controls | None | All PR workflows |
| Dependency guard | None | All CI workflows |
| Dependabot for Actions | None | Weekly checks |

## Test plan
- [ ] CI tests pass with new workflow structure
- [ ] Linter workflow runs correctly
- [ ] E2E tests pass
- [ ] Dependency guard triggers on go.mod changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)