### PR TITLE
[TT-17030] Migrate CLA workflow from PAT to GitHub App token

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -15,12 +15,22 @@ jobs:
   CLAssistant:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+          repositories: cla
+
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@b2a7f9fb90217ea0b8a0c95c288221457be4a31f # v2.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://github.com/TykTechnologies/tyk/blob/master/CLA.md'


### PR DESCRIPTION
## Summary
Proof-of-concept for replacing `ORG_GH_TOKEN` (personal access token) with GitHub App tokens across the org.

### What changed
```diff
- PERSONAL_ACCESS_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+ PERSONAL_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
```

A new step generates a short-lived token from the **probelabs** GitHub App using `actions/create-github-app-token`, scoped to only the `TykTechnologies/cla` repository.

### Why this matters
- PATs are long-lived, tied to a person, and have broad scope
- GitHub App tokens are short-lived (1 hour), tied to the app, and can be scoped to specific repos
- This enables disabling PATs at the org level without breaking workflows

### How to test
1. An external contributor opens a PR on this repo
2. The CLA assistant should prompt them to sign
3. When they sign, the signature should be committed to `TykTechnologies/cla`

If this works, the same pattern can be applied to all ~24 repos with CLA workflows, and then extended to other `ORG_GH_TOKEN` use cases.

## Test plan
- [ ] CLA assistant triggers on a new PR
- [ ] Signature is stored in TykTechnologies/cla repo
- [ ] No PAT used — only GitHub App token

🤖 Generated with [Claude Code](https://claude.com/claude-code)