### PR TITLE
TT-17154 Clarify config struct comments for docs generation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -140,14 +140,10 @@ type TLS struct {
 	// Path to the key file.
 	KeyFile string `json:"key_file"`
 	// Maximum TLS version negotiated with the OpenTelemetry collector.
-	// Options: ["1.0", "1.1", "1.2", "1.3"]. When unset, Tyk applies "1.3"
-	// as the default (this is enforced by Tyk, not inherited from Go's
-	// `crypto/tls` package).
+	// Options: ["1.0", "1.1", "1.2", "1.3"]. Defaults to "1.3".
 	MaxVersion string `json:"max_version"`
 	// Minimum TLS version negotiated with the OpenTelemetry collector.
-	// Options: ["1.0", "1.1", "1.2", "1.3"]. When unset, Tyk applies "1.2"
-	// as the default (this is enforced by Tyk, not inherited from Go's
-	// `crypto/tls` package).
+	// Options: ["1.0", "1.1", "1.2", "1.3"]. Defaults to "1.2".
 	MinVersion string `json:"min_version"`
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -16,12 +16,13 @@ type ExporterConfig struct {
 	// Timeout for establishing a connection to the collector.
 	// Defaults to 1 second.
 	ConnectionTimeout int `json:"connection_timeout"`
-	// Service name reported as the OpenTelemetry resource. This identifies the
-	// Tyk Gateway instance in the collected traces and metrics, and typically
-	// appears as `service.name` in backends such as Jaeger, Tempo or Prometheus.
+	// The "Resource" or "Service" Name that will be assigned to the Gateway in
+	// traces and metrics. This is used to identify OpenTelemetry data generated
+	// by Tyk Gateway. It typically appears as `service.name` in backends
+	// such as Jaeger, Tempo or Prometheus.
 	// Defaults to "tyk".
 	ResourceName string `json:"resource_name"`
-	// TLS configuration for the exporter.
+	// TLS configuration used by the exporter to authenticate the OpenTelemetry collector
 	TLS TLS `json:"tls"`
 }
 
@@ -127,13 +128,13 @@ type TLS struct {
 	// Set this to `true` to enable TLS for the connection to the OpenTelemetry
 	// collector. Defaults to false.
 	Enable bool `json:"enable"`
-	// Flag that can be used to skip TLS verification if TLS is enabled.
+	// Set to `true` to disable verification of the server’s certificate chain. Not recommended for production environments.
 	// Defaults to false.
 	InsecureSkipVerify bool `json:"insecure_skip_verify"`
 	// Filesystem path to a PEM-encoded CA certificate used to verify the
 	// OpenTelemetry collector's TLS certificate. Only filesystem paths are
-	// accepted; certificate IDs from the Tyk certificate store are not
-	// supported here.
+	// accepted; certificate IDs from the Tyk Certificate Store are not
+	// supported.
 	CAFile string `json:"ca_file"`
 	// Path to the cert file.
 	CertFile string `json:"cert_file"`

--- a/config/config.go
+++ b/config/config.go
@@ -139,11 +139,13 @@ type TLS struct {
 	CertFile string `json:"cert_file"`
 	// Path to the key file.
 	KeyFile string `json:"key_file"`
-	// Maximum TLS version negotiated with the OpenTelemetry collector.
-	// Options: ["1.0", "1.1", "1.2", "1.3"]. Defaults to "1.3".
+	// Maximum TLS version that is supported.
+	// Options: ["1.0", "1.1", "1.2", "1.3"].
+	// Defaults to "1.3".
 	MaxVersion string `json:"max_version"`
-	// Minimum TLS version negotiated with the OpenTelemetry collector.
-	// Options: ["1.0", "1.1", "1.2", "1.3"]. Defaults to "1.2".
+	// Minimum TLS version that is supported.
+	// Options: ["1.0", "1.1", "1.2", "1.3"].
+	// Defaults to "1.2".
 	MinVersion string `json:"min_version"`
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -4,10 +4,9 @@ package config
 // It is embedded by both OpenTelemetry (traces) and MetricsConfig (metrics)
 // so each can target a different collector independently.
 type ExporterConfig struct {
-	// The type of the exporter to sending data in OTLP protocol.
-	// This should be set to the same type of the OpenTelemetry collector.
-	// Valid values are "grpc", or "http".
-	// Defaults to "grpc".
+	// Transport used to send telemetry data to the OpenTelemetry collector
+	// over OTLP. Must match the protocol the collector is configured to accept.
+	// Valid values are "grpc" or "http". Defaults to "grpc".
 	Exporter string `json:"exporter"`
 	// OpenTelemetry collector endpoint to connect to.
 	// Defaults to "localhost:4317".
@@ -17,7 +16,9 @@ type ExporterConfig struct {
 	// Timeout for establishing a connection to the collector.
 	// Defaults to 1 second.
 	ConnectionTimeout int `json:"connection_timeout"`
-	// Name of the resource that will be used to identify the resource.
+	// Service name reported as the OpenTelemetry resource. This identifies the
+	// Tyk Gateway instance in the collected traces and metrics, and typically
+	// appears as `service.name` in backends such as Jaeger, Tempo or Prometheus.
 	// Defaults to "tyk".
 	ResourceName string `json:"resource_name"`
 	// TLS configuration for the exporter.
@@ -25,7 +26,9 @@ type ExporterConfig struct {
 }
 
 type OpenTelemetry struct {
-	// A flag that can be used to enable or disable the trace exporter.
+	// Set this to `true` to enable OpenTelemetry tracing on the Gateway.
+	// When enabled, the Gateway exports spans to the configured OpenTelemetry
+	// collector. Defaults to false.
 	Enabled bool `json:"enabled"`
 	// Shared exporter/transport configuration.
 	ExporterConfig `json:",inline"`
@@ -121,24 +124,30 @@ type MetricsRetryConfig struct {
 }
 
 type TLS struct {
-	// Flag that can be used to enable TLS. Defaults to false (disabled).
+	// Set this to `true` to enable TLS for the connection to the OpenTelemetry
+	// collector. Defaults to false.
 	Enable bool `json:"enable"`
 	// Flag that can be used to skip TLS verification if TLS is enabled.
 	// Defaults to false.
 	InsecureSkipVerify bool `json:"insecure_skip_verify"`
-	// Path to the CA file.
+	// Filesystem path to a PEM-encoded CA certificate used to verify the
+	// OpenTelemetry collector's TLS certificate. Only filesystem paths are
+	// accepted; certificate IDs from the Tyk certificate store are not
+	// supported here.
 	CAFile string `json:"ca_file"`
 	// Path to the cert file.
 	CertFile string `json:"cert_file"`
 	// Path to the key file.
 	KeyFile string `json:"key_file"`
-	// Maximum TLS version that is supported.
-	// Options: ["1.0", "1.1", "1.2", "1.3"].
-	// Defaults to "1.3".
+	// Maximum TLS version negotiated with the OpenTelemetry collector.
+	// Options: ["1.0", "1.1", "1.2", "1.3"]. When unset, Tyk applies "1.3"
+	// as the default (this is enforced by Tyk, not inherited from Go's
+	// `crypto/tls` package).
 	MaxVersion string `json:"max_version"`
-	// Minimum TLS version that is supported.
-	// Options: ["1.0", "1.1", "1.2", "1.3"].
-	// Defaults to "1.2".
+	// Minimum TLS version negotiated with the OpenTelemetry collector.
+	// Options: ["1.0", "1.1", "1.2", "1.3"]. When unset, Tyk applies "1.2"
+	// as the default (this is enforced by Tyk, not inherited from Go's
+	// `crypto/tls` package).
 	MinVersion string `json:"min_version"`
 }
 


### PR DESCRIPTION
## Description

Improves user-facing documentation generated from comments on the config structs. Changes are documentation-only — no behavior, signatures, or defaults are modified.

Field-by-field changes:

- **`ExporterConfig.Exporter`** — Fixed broken grammar (*"to sending data in OTLP protocol"*) and described the field as the OTLP transport that must match the collector's protocol.
- **`ExporterConfig.ResourceName`** — Replaced the circular description (*"Name of the resource that will be used to identify the resource"*) with concrete meaning: the service name reported as the OpenTelemetry resource, identifying the Gateway in backends.
- **`OpenTelemetry.Enabled`** and **`TLS.Enable`** — Adopted Tyk's standard `"Set this to true to enable..."` phrasing for consistency with the rest of the gateway config.
- **`TLS.CAFile`** — Clarified that only filesystem paths are accepted; certificate IDs from the Tyk certificate store are not supported here (reviewer asked whether it accepts cert IDs).

## Motivation and Context

PR review feedback on the gateway-side OpenTelemetry config documentation noted that several generated doc entries were unclear, used inconsistent phrasing, or had grammar issues. Because the docs are generated from these struct comments, the fixes belong in this library.

## Out of scope

One review comment asked why TLS settings here are not part of `ExternalServiceConfig` (the centralized external-service config in the gateway). That's an architectural question — folding the library's TLS struct into `ExternalServiceConfig` would require coordination with other consumers of this library and isn't a doc-only fix. Tracking that separately.

The `Traces` field comment fix (replacing *"non-nil"* with *"when set"*) lives in the `tyk` repo and is being handled as a separate change there.

## Test Coverage For This Change

Comment-only change. Verified locally:

- `go build ./...` — compiles clean.
- `gofmt -l config/config.go` — no formatting issues.

## Types of changes

- [x] Documentation updates or improvements.

## Checklist

- [x] I have reviewed the guidelines for contributing to this repository.
- [x] Pull request is from a topic branch, not `main`.
- [x] PR targets `main`.
- [x] Lint checks pass (`gofmt -s -w .`, `go vet ./...`).